### PR TITLE
Only reconnect to IRC if not shutting down.

### DIFF
--- a/fmn/consumer/backends/base.py
+++ b/fmn/consumer/backends/base.py
@@ -3,6 +3,8 @@ import fmn.lib.models
 
 
 class BaseBackend(object):
+    die = False
+
     def __init__(self, config, session, **kwargs):
         self.config = config
         self.session = session
@@ -37,3 +39,6 @@ class BaseBackend(object):
 
     def disable(self, detail_value):
         self.preference_for(detail_value).set_enabled(self.session, False)
+
+    def stop(self):
+        self.die = True

--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -65,3 +65,9 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
                     log.debug("    Queueing msg for digest")
                     fmn.lib.models.QueuedMessage.enqueue(
                         self.session, user, context, msg)
+
+    def stop(self):
+        log.info("Cleaning up FMNConsumer.")
+        for context, backend in self.backends.iteritems():
+            backend.stop()
+        super(FMNConsumer, self).stop()


### PR DESCRIPTION
As things stand right now, when the irc bot loses its connection, it just
tries to reconnect.  If it can't do that, then it waits 60 seconds and tries
again.. forever.  This is good, generally.  If our bot goes offline due to a
netsplit or something, it can get itself back on freenode without human
intervention.

However, if we're trying to stop the bot.. say, with
`service fedmsg-hub restart` or a simple control-c, then it loses its 
connection and, before it can finish terminating, tries to reconnect again. 
It never actually exits and you have to hit it with `kill -9`.

This commit makes it so that when the core hub calls `.stop()` on the
`FMNConsumer`, then that consumer will tell its subordinates to give up the
:ghost:.
