### PR TITLE
This thing doesn't actually have access to the config.

### DIFF
--- a/fmn/consumer/backends/irc.py
+++ b/fmn/consumer/backends/irc.py
@@ -296,7 +296,8 @@ class IRCBackendProtocol(twisted.words.protocols.irc.IRCClient):
         if user == "NickServ!NickServ@services.":
             nick, commands, result = msg.split(None, 2)
 
-            s = fmn.lib.models.init(self.config.get('fmn.sqlalchemy.uri'))
+            uri = self.factory.parent.config.get('fmn.sqlalchemy.uri'))
+            s = fmn.lib.models.init(uri)
 
             if result.strip() == '3':
                 # Then all is good.


### PR DESCRIPTION
This was causing a bug where the bot would query NickServ, NickServ would
respond.  The irc bot would traceback, and try again.  We spammed NickServ over
and over again, unable to "hear" its reply.

Not sure when this got introduced, but this is a backport from a hotfix -- it
is definitely hammered out in production at this point.
