### PR TITLE
Undo tuple arguments to email module.

### DIFF
--- a/fmn/consumer/backends/mail.py
+++ b/fmn/consumer/backends/mail.py
@@ -44,17 +44,15 @@ class EmailBackend(BaseBackend):
             return
 
         email_message = email.Message.Message()
-        to_addr = ('utf-8', None, to_bytes(recipient['email address']))
-        email_message.add_header('To', to_addr)
-        from_addr = ('utf-8', None, to_bytes(self.from_address))
-        email_message.add_header('From', from_addr)
+        email_message.add_header('To', to_bytes(recipient['email address']))
+        email_message.add_header('From', to_bytes(self.from_address))
 
         subject_prefix = self.config.get('fmn.email.subject_prefix', '')
         if subject_prefix:
             subject = '{0} {1}'.format(
                 subject_prefix.strip(), subject.strip())
 
-        email_message.add_header('Subject', ('utf-8', None, to_bytes(subject)))
+        email_message.add_header('Subject', to_bytes(subject))
 
         # Since we do simple text email, adding the footer to the content
         # before setting the payload.
@@ -67,7 +65,7 @@ class EmailBackend(BaseBackend):
         if footer:
             content += u'\n\n--\n{0}'.format(footer.strip())
 
-        email_message.set_payload(('utf-8', None, to_bytes(content)))
+        email_message.set_payload(to_bytes(content))
 
         server = smtplib.SMTP(self.mailserver)
         try:


### PR DESCRIPTION
We thought for some reason there was this 'tuple' interface where you could
pass in the headers declaring their encoding.. but, it just didn't work.
When I deployed this, it complained everywhere that it expected strings --
not tuples.
