### PR TITLE
Only create account for sponsee.

### DIFF
--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -109,16 +109,15 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
         if '.fas.group.member.sponsor' in topic:
             group = msg['msg']['group']
             if group == 'packager':
-                usernames = fedmsg.meta.msg2usernames(msg, **self.hub.config)
-                for username in usernames:
-                    openid='%s.id.fedoraproject.org' % username
-                    openid_url = 'https://%s.id.fedoraproject.org' % username
-                    email = '%s@fedoraproject.org' % username
-                    user = fmn.lib.models.User.get_or_create(
-                        session, openid=openid, openid_url=openid_url,
-                        create_defaults=True, detail_values=dict(email=email),
-                    )
-                    session.add(user)
+                username = msg['msg']['user']
+                openid='%s.id.fedoraproject.org' % username
+                openid_url = 'https://%s.id.fedoraproject.org' % username
+                email = '%s@fedoraproject.org' % username
+                user = fmn.lib.models.User.get_or_create(
+                    session, openid=openid, openid_url=openid_url,
+                    create_defaults=True, detail_values=dict(email=email),
+                )
+                session.add(user)
                 session.commit()
                 self.refresh_cache(session, topic, msg)
 


### PR DESCRIPTION
Fixes fedora-infra/fmn#35.

This used to create a new account for _everyone_ involved in a sponsor
event, the sponsor and the sponsee included.  This changes it so that an
account is created only for the sponsee.
