### PR TITLE
Implement one-shot filters in the consumer

### DIFF
--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -210,6 +210,11 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
                     log.debug("    Queueing msg for digest")
                     fmn.lib.models.QueuedMessage.enqueue(
                         session, user, context, msg)
+                if ('filter_oneshot' in recipient
+                        and recipient['filter_oneshot']):
+                    log.debug("    Marking one-shot filter as fired")
+                    fltr = fmn.lib.models.Filter.get(recipient['filter_id'])
+                    fltr.fired(session)
 
         log.debug("Done.  %0.2fs %s %s",
                   time.time() - start, msg['msg_id'], msg['topic'])


### PR DESCRIPTION
Related to fedora-infra/fmn.lib#37
Will work with a lib version that doesn't have one-shot filters

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>