### PR TITLE
Employ the verbose value to send more or less details in a digest email.

### DIFF
--- a/fmn/consumer/backends/mail.py
+++ b/fmn/consumer/backends/mail.py
@@ -110,7 +110,10 @@ class EmailBackend(BaseBackend):
         def _format_line(msg):
             timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])
             link = fedmsg.meta.msg2link(msg, **self.config) or u''
-            payload = fedmsg.meta.msg2long_form(msg, **self.config) or u''
+            if recipient['verbose']:
+                payload = fedmsg.meta.msg2long_form(msg, **self.config) or u''
+            else:
+                payload = fedmsg.meta.msg2subtitle(msg, **self.config) or u''
             return timestamp.strftime("%c") + ", " + payload + "\n\t" + link
 
         n = len(queued_messages)


### PR DESCRIPTION
This is the last missing piece for fedora-infra/fmn#67.

Requires fedora-infra/fmn.lib#41.