### PR TITLE
Make mail handler deal with bad emails.

### DIFF
--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -10,6 +10,12 @@ import fmn.lib
 import fmn.rules.utils
 import backends as fmn_backends
 
+from fmn.consumer.utils import (
+    new_packager,
+    new_badges_user,
+    get_fas_email,
+)
+
 import logging
 log = logging.getLogger("fmn")
 
@@ -224,37 +230,3 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
         for context, backend in self.backends.iteritems():
             backend.stop()
         super(FMNConsumer, self).stop()
-
-
-def new_packager(topic, msg):
-    """ Returns a username if the message is about a new packager in FAS. """
-    if '.fas.group.member.sponsor' in topic:
-        group = msg['msg']['group']
-        if group == 'packager':
-            return msg['msg']['user']
-    return None
-
-
-def new_badges_user(topic, msg):
-    """ Returns a username if the message is about a new fedbadges user. """
-    if '.fedbadges.person.login.first' in topic:
-        return msg['msg']['user']['username']
-    return None
-
-
-def get_fas_email(config, username):
-    """ Return FAS email associated with a username.
-
-    We use this to try and get the right email for new autocreated users.
-    We used to just use $USERNAME@fp.o, but when first created most users don't
-    have that alias available yet.
-    """
-    try:
-        fas = fedora.client.AccountSystem(**config['fas_credentials'])
-        person = fas.person_by_username(username)
-        if person.email:
-            return person.email
-        raise ValueError("No email found: %r, %r" % (person.email, username))
-    except Exception:
-        log.exception("Failed to get FAS email for %r" % username)
-        return '%s@fedoraproject.org' % username

--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -10,7 +10,7 @@ import fmn.lib
 import fmn.rules.utils
 import backends as fmn_backends
 
-from fmn.consumer.utils import (
+from fmn.consumer.util import (
     new_packager,
     new_badges_user,
     get_fas_email,

--- a/fmn/consumer/util.py
+++ b/fmn/consumer/util.py
@@ -1,0 +1,38 @@
+import fedora.client
+
+import logging
+log = logging.getLogger("fmn")
+
+
+def new_packager(topic, msg):
+    """ Returns a username if the message is about a new packager in FAS. """
+    if '.fas.group.member.sponsor' in topic:
+        group = msg['msg']['group']
+        if group == 'packager':
+            return msg['msg']['user']
+    return None
+
+
+def new_badges_user(topic, msg):
+    """ Returns a username if the message is about a new fedbadges user. """
+    if '.fedbadges.person.login.first' in topic:
+        return msg['msg']['user']['username']
+    return None
+
+
+def get_fas_email(config, username):
+    """ Return FAS email associated with a username.
+
+    We use this to try and get the right email for new autocreated users.
+    We used to just use $USERNAME@fp.o, but when first created most users don't
+    have that alias available yet.
+    """
+    try:
+        fas = fedora.client.AccountSystem(**config['fas_credentials'])
+        person = fas.person_by_username(username)
+        if person.email:
+            return person.email
+        raise ValueError("No email found: %r, %r" % (person.email, username))
+    except Exception:
+        log.exception("Failed to get FAS email for %r" % username)
+        return '%s@fedoraproject.org' % username


### PR DESCRIPTION
Currently it just emails us.  This tries to:

1) get a good email from fas
2) failing that, disable the account.

Fixes fedora-infra/fmn#28.