### PR TITLE
Use regular handling when batch contains only one message.

### DIFF
--- a/fmn/consumer/backends/android.py
+++ b/fmn/consumer/backends/android.py
@@ -49,7 +49,7 @@ class GCMBackend(BaseBackend):
           pref.update_details(sess, j.get("message_id").get("registration_id"))
 
 
-    def handle(self, session, recipient, msg):
+    def handle(self, session, recipient, msg, streamline=False):
         self.log.debug("Notifying via gcm/android %r" % recipient)
 
         if 'registration id' not in recipient:

--- a/fmn/consumer/backends/base.py
+++ b/fmn/consumer/backends/base.py
@@ -1,8 +1,11 @@
+import abc
+
 import logging
 import fmn.lib.models
 
 
 class BaseBackend(object):
+    __metaclass__ = abc.ABCMeta
     die = False
 
     def __init__(self, config, **kwargs):
@@ -10,14 +13,17 @@ class BaseBackend(object):
         self.log = logging.getLogger("fmn")
 
     # Some methods that must be implemented by backends.
-    def handle(self, session, recipient, msg):
-        raise NotImplementedError("BaseBackend must be extended")
+    @abc.abstractmethod
+    def handle(self, session, recipient, msg, streamline=False):
+        pass
 
+    @abc.abstractmethod
     def handle_batch(self, session, queued_messages):
-        raise NotImplementedError("BaseBackend must be extended")
+        pass
 
+    @abc.abstractmethod
     def handle_confirmation(self, session, confirmation):
-        raise NotImplementedError("BaseBackend must be extended")
+        pass
 
     # Some helper methods for our child classes.
     def context_object(self, session):

--- a/fmn/consumer/backends/mail.py
+++ b/fmn/consumer/backends/mail.py
@@ -97,7 +97,7 @@ class EmailBackend(BaseBackend):
             server.quit()
         self.log.debug("Email sent")
 
-    def handle(self, session, recipient, msg):
+    def handle(self, session, recipient, msg, streamline=False):
         topic = msg['topic']
         category = topic.split('.')[3]
 


### PR DESCRIPTION
This should fix fedora-infra/fmn#91.

Furthermore, this standardizes the streamline=False argument across the backend
implementations. The IRC backend had it already and the email and android
backends didn't. This adds it everywhere and then forces compliance with a
stdlib abstract base class.