### PR TITLE
Drop batched messages if disabled.

### DIFF
--- a/fmn/consumer/producer.py
+++ b/fmn/consumer/producer.py
@@ -119,6 +119,13 @@ class DigestProducer(FMNProducerBase):
             log.info("* Found %r queued messages" % len(queued_messages))
 
         for recipient in recipients:
+
+            # If the preference is disabled, then drop all those queued
+            # messages.
+            if not pref.enabled:
+                log.info("* Pref %r inactive.  Dropping messages." % pref)
+                continue
+
             # If there's only a single message, then send it in "the usual way"
             # See https://github.com/fedora-infra/fmn/issues/91
             if len(queued_messages) == 1:


### PR DESCRIPTION
It makes sense.  If the user was active for a while, and we queued up 500
messages for them, but then they change their mind and they want to disable
their account, we shouldn't send them those 500 messages "when the time comes".

I'm hitting this in stg right now.  I have a bunch of messages queued up for my
testing account that are buggy (because I was testing stuff) and now it's stuck
in an infinite loop where the digest timer fires, it goes to send me my 500
messages in digest and it fails because they're weird buggy messages.  I
disabled my staging account, but the loop is still going.. and the messages
never get de-queued.