### PR TITLE
Add separator between messages in digest

### DIFF
--- a/fmn/consumer/backends/mail.py
+++ b/fmn/consumer/backends/mail.py
@@ -148,7 +148,7 @@ class EmailBackend(BaseBackend):
 
         n = len(queued_messages)
         subject = u"Fedora Notifications Digest (%i updates)" % n
-        separator = "\n\n" + "-"*80 + "\n\n"
+        separator = "\n\n" + "-"*79 + "\n\n"
         content = separator.join([
             _format_line(queued_message.message)
             for queued_message in queued_messages])

--- a/fmn/consumer/backends/mail.py
+++ b/fmn/consumer/backends/mail.py
@@ -148,7 +148,8 @@ class EmailBackend(BaseBackend):
 
         n = len(queued_messages)
         subject = u"Fedora Notifications Digest (%i updates)" % n
-        content = "\n".join([
+        separator = "\n\n" + "-"*80 + "\n\n"
+        content = separator.join([
             _format_line(queued_message.message)
             for queued_message in queued_messages])
 


### PR DESCRIPTION
See Issue #117 on fedora-infra/fmn

> In a digest email actually every message is printed after the preceding without any space, so it's hard to read the digest.
> Would be possible to add a separator between messages to better formatting the digest?

I've modified the separator in the join function that creates the content of the digest with a very simple line of "-" for 80 columns.

This is my first time using Github pull request, so excuse me if I do something wrong here...