### PR TITLE
Digest summary

### DIFF
--- a/fmn/consumer/backends/mail.py
+++ b/fmn/consumer/backends/mail.py
@@ -148,8 +148,17 @@ class EmailBackend(BaseBackend):
 
         n = len(queued_messages)
         subject = u"Fedora Notifications Digest (%i updates)" % n
+        summary = u"Digest summary:\n"
+        for msg_number in range(len(queued_messages)):
+            summary += str(msg_number+1) + ".\t" + (fedmsg.meta.msg2subtitle(msg, **self.config) or u'') + "\n"
+        
         separator = "\n\n" + "-"*79 + "\n\n"
-        content = separator.join([
+        if recipient.get('verbose', True):
+            content = summary + separator
+        else:
+            content = u''
+        
+        content += separator.join([
             _format_line(queued_message.message)
             for queued_message in queued_messages])
 


### PR DESCRIPTION
What about to add a short summary of the messages at the top of the digest when messages are set to verbose mode?
This can help to have a quick look of digest's contents without losing the details in the email.