### PR TITLE
Add a debug backend

### DIFF
--- a/fedmsg.d/fmn.py
+++ b/fedmsg.d/fmn.py
@@ -45,6 +45,7 @@ config = {
     # This is the list of enabled backends (so we can turn one off globally)
     #"fmn.backends": ['email', 'irc', 'android'],
     "fmn.backends": ['email', 'irc'],
+    "fmn.backends.debug": False,
 
     # Email
     "fmn.email.mailserver": "127.0.0.1:25",

--- a/fmn/consumer/backends/__init__.py
+++ b/fmn/consumer/backends/__init__.py
@@ -1,3 +1,4 @@
 from mail import EmailBackend
 from irc import IRCBackend
 from android import GCMBackend
+from debug import DebugBackend

--- a/fmn/consumer/backends/debug.py
+++ b/fmn/consumer/backends/debug.py
@@ -1,0 +1,110 @@
+from fmn.consumer.backends.base import BaseBackend
+import fedmsg.meta
+
+import datetime
+
+
+class DebugBackend(BaseBackend):
+    __context_name__ = "debug"
+
+    def __init__(self, *args, **kwargs):
+        super(DebugBackend, self).__init__(*args, **kwargs)
+
+
+    def handle(self, session, recipient, msg, streamline=False):
+        topic = msg['topic']
+        category = topic.split('.')[3]
+
+        link = fedmsg.meta.msg2link(msg, **self.config) or u''
+        content = fedmsg.meta.msg2long_form(msg, **self.config) or u''
+        subject = fedmsg.meta.msg2subtitle(msg, **self.config) or u''
+
+        usernames = fedmsg.meta.msg2usernames(msg, **self.config)
+        packages = fedmsg.meta.msg2packages(msg, **self.config)
+
+        print '  -- Single message --'
+        print 'recipient:   ', recipient
+        print 'subject:     ', subject,
+        print 'content:     ', content + "\n\t" + link
+        print 'topic:       ', [topic]
+        print 'category:    ', [category]
+        print 'usernames:   ', usernames
+        print 'packages:    ', packages
+
+    def handle_batch(self, session, recipient, queued_messages):
+        def _format_line(msg):
+            timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])
+            link = fedmsg.meta.msg2link(msg, **self.config) or u''
+            payload = fedmsg.meta.msg2subtitle(msg, **self.config) or u''
+
+            if recipient.get('verbose', True):
+                longform = fedmsg.meta.msg2long_form(msg, **self.config) or u''
+                if longform:
+                    payload += "\n" + longform
+
+            return timestamp.strftime("%c") + ", " + payload + "\n\t" + link
+
+        n = len(queued_messages)
+        subject = u"Fedora Notifications Digest (%i updates)" % n
+        summary = u"Digest summary:\n"
+        for i, msg in enumerate(queued_messages):
+            line = fedmsg.meta.msg2subtitle(msg.message, **self.config) or u''
+            summary += str(i+1) + ".\t" + line + "\n"
+
+        separator = "\n\n" + "-"*79 + "\n\n"
+        if recipient.get('verbose', True):
+            content = summary + separator
+        else:
+            content = u''
+
+        content += separator.join([
+            _format_line(queued_message.message)
+            for queued_message in queued_messages])
+
+        topics = set([q.message['topic'] for q in queued_messages])
+        categories = set([topic.split('.')[3] for topic in topics])
+
+        squash = lambda items: reduce(set.union, items, set())
+        usernames = squash([
+            fedmsg.meta.msg2usernames(q.message, **self.config)
+            for q in queued_messages])
+        packages = squash([
+            fedmsg.meta.msg2packages(q.message, **self.config)
+            for q in queued_messages])
+
+        print '  -- Batch --'
+        print 'recipient:   ', recipient
+        print 'subject:     ', subject,
+        print 'content:     ', content
+        print 'topic:       ', topics
+        print 'category:    ', categories
+        print 'usernames:   ', usernames
+        print 'packages:    ', packages
+
+
+    def handle_confirmation(self, session, confirmation):
+        confirmation.set_status(session, 'valid')
+        acceptance_url = self.config['fmn.acceptance_url'].format(
+            secret=confirmation.secret)
+        rejection_url = self.config['fmn.rejection_url'].format(
+            secret=confirmation.secret)
+
+        template = self.config.get('fmn.mail_confirmation_template',
+                                   CONFIRMATION_TEMPLATE)
+        content = template.format(
+            acceptance_url=acceptance_url,
+            rejection_url=rejection_url,
+            support_email=self.config['fmn.support_email'],
+            username=confirmation.openid,
+        ).strip()
+
+        recipient = {
+            'user': confirmation.user.openid,
+            'email address': confirmation.detail_value,
+            'triggered_by_links': False,
+        }
+
+        print '  -- Confirmation --'
+        print 'recipient:   ', recipient
+        print 'content:     ', content
+

--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -55,6 +55,13 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
                 raise ValueError("%r in fmn.backends (%r) is invalid" % (
                     key, self.hub.config['fmn.backends']))
 
+        # If debug is enabled, use the debug backend everywhere
+        if self.hub.config.get('fmn.backends.debug', False):
+            for key in self.backends:
+                log.debug('Setting %s to use the DebugBackend' % key)
+                self.backends[key] = fmn_backends.DebugBackend(
+                    **backend_kwargs)
+
         log.debug("Loading rules from fmn.rules")
         self.valid_paths = fmn.lib.load_rules(root="fmn.rules")
 


### PR DESCRIPTION
If one sets `fmn.backends.debug` to `True` in the configuration, this
backend will be used in place of all the other ones.
This allows to keep the web UI running normally without having to deal
with the worry of sending emails or IRC notifications.